### PR TITLE
New config options added + gamerule fix

### DIFF
--- a/LongerDays.iml
+++ b/LongerDays.iml
@@ -1,26 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_17">
-    <output url="file://$MODULE_DIR$/target/classes" />
-    <output-test url="file://$MODULE_DIR$/target/test-classes" />
-    <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.19-R0.1-SNAPSHOT" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:31.0.1-jre" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:failureaccess:1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:3.12.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.errorprone:error_prone_annotations:2.7.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.j2objc:j2objc-annotations:1.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.8.9" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.16-R0.4" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:1.30" level="project" />
+<module version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+      </configuration>
+    </facet>
   </component>
 </module>

--- a/src/main/java/me/foncused/longerdays/LongerDays.java
+++ b/src/main/java/me/foncused/longerdays/LongerDays.java
@@ -40,7 +40,7 @@ public class LongerDays extends JavaPlugin {
 	}
 
 	private void registerEvents() {
-		this.getServer().getPluginManager().registerEvents(new PlayerBed(), this);
+		this.getServer().getPluginManager().registerEvents(new PlayerBed(getConfigManager()), this);
 	}
 
 	private void registerRunnables() {

--- a/src/main/java/me/foncused/longerdays/config/ConfigManager.java
+++ b/src/main/java/me/foncused/longerdays/config/ConfigManager.java
@@ -15,6 +15,11 @@ public class ConfigManager {
 	private int night;
 	private Set<String> worlds;
 
+	private boolean nightSkippingEnabled;
+	private boolean percentageEnabled;
+	private int percentage;
+
+
 	public ConfigManager(final FileConfiguration config) {
 		this.config = config;
 	}
@@ -47,6 +52,9 @@ public class ConfigManager {
 		this.worlds.addAll(worlds);
 		this.worlds = Collections.unmodifiableSet(this.worlds);
 
+		percentageEnabled =  this.config.getBoolean("players-sleeping-percentage.enabled");
+		percentage = this.config.getInt("players-sleeping-percentage.percentage");
+		nightSkippingEnabled = this.config.getBoolean("night-skipping.enabled");
 	}
 
 	public int getDay() {
@@ -61,4 +69,15 @@ public class ConfigManager {
 		return Collections.unmodifiableSet(this.worlds);
 	}
 
+	public boolean isPercentageEnabled() {
+		return percentageEnabled;
+	}
+
+	public int getPercentage() {
+		return percentage;
+	}
+
+	public boolean isNightSkippingEnabled() {
+		return nightSkippingEnabled;
+	}
 }

--- a/src/main/java/me/foncused/longerdays/event/player/PlayerBed.java
+++ b/src/main/java/me/foncused/longerdays/event/player/PlayerBed.java
@@ -1,5 +1,7 @@
 package me.foncused.longerdays.event.player;
 
+import me.foncused.longerdays.LongerDays;
+import me.foncused.longerdays.config.ConfigManager;
 import me.foncused.longerdays.util.LongerDaysUtil;
 import org.bukkit.GameRule;
 import org.bukkit.World;
@@ -10,13 +12,39 @@ import org.bukkit.event.player.PlayerBedLeaveEvent;
 
 public class PlayerBed implements Listener {
 
+	private final ConfigManager configManager;
 	private int sleeping;
+
+	public PlayerBed(ConfigManager configManager) {
+		this.configManager = configManager;
+	}
 
 	@EventHandler
 	public void onPlayerBedEnter(final PlayerBedEnterEvent event) {
 		this.sleeping++;
+
+		//do nothing if night skipping is disabled
+		if(!configManager.isNightSkippingEnabled()){
+			return;
+		}
+
 		final World world = event.getPlayer().getWorld();
-		final int percentage = world.getGameRuleValue(GameRule.PLAYERS_SLEEPING_PERCENTAGE);
+
+		int percentage;
+
+
+		if(!configManager.isPercentageEnabled()){
+
+			try{
+				percentage = world.getGameRuleValue(GameRule.PLAYERS_SLEEPING_PERCENTAGE);
+			} catch (Exception e) {
+				LongerDaysUtil.consoleWarning("Could not fetch game-rule value 'playersSleepingPercentage!" +
+						" Please go to the config.yml and enable players-sleeping-percentage");
+				return;
+			}
+		}
+
+		percentage = configManager.getPercentage();
 		if(LongerDaysUtil.isNight(world)
 				&& event.getBedEnterResult() == PlayerBedEnterEvent.BedEnterResult.OK
 				&& (this.sleeping / world.getPlayers().size()) * 100 >= percentage) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,3 +11,13 @@ night: 5
 # Worlds to enable
 worlds:
   - "world"
+
+# when this option is enabled, you can skip the night
+night-skipping:
+  enabled: false
+
+# If your server doesn't have the 'playersSleepingPercentage' game-rule, you can still control the percentage
+players-sleeping-percentage:
+  enabled: false
+  percentage: 50
+


### PR DESCRIPTION
Hello there

So someone contacted me that your plugin would possibly conflict wtih my Sleep-Most plugin which I checked is not the case. Since your plugin is open source I could help myself to improve it. The issue he faced is an error:

`Caused by: java.lang.NoSuchFieldError: PLAYERS_SLEEPING_PERCENTAGE at me.foncused.longerdays.event.player.PlayerBed.onPlayerBedEnter(PlayerBed.java:19) ~[?:?]
`

This error was caused because the client he was using doesn't have playerSleepPercentage gamerule. I saw you also didn't include any validation for that so I decided to implement some new features.

Added the following config options:
```yml
# when this option is enabled, you can skip the night
night-skipping:
  enabled: false

# If your server doesn't have the 'playersSleepingPercentage' game-rule, you can still control the percentage
players-sleeping-percentage:
  enabled: false
  percentage: 50
```

The idea of this implementation has two main goals:

- Allowing players to decide if they want to use night skipping features (rather then forcing it to the gamerule)
- In case server owners use a version that doesn't have the 'playerSLeepPercentage' gamerule, still offering a config option for them to use this feature.
